### PR TITLE
Change parameters positions in assertions

### DIFF
--- a/test/Handler/StandardCommandHandlerLocatorTest.php
+++ b/test/Handler/StandardCommandHandlerLocatorTest.php
@@ -24,6 +24,6 @@ class StandardCommandHandlerLocatorTest extends \PHPUnit_Framework_TestCase
             ->willReturn($commandHandler);
         $commandHandlerLocator = new StandardCommandHandlerLocator($commandHandlerMap);
 
-        $this->assertSame($commandHandlerLocator->getHandler($command), $commandHandler);
+        $this->assertSame($commandHandler, $commandHandlerLocator->getHandler($command));
     }
 }

--- a/test/Map/InMemoryCommandHandlerMapTest.php
+++ b/test/Map/InMemoryCommandHandlerMapTest.php
@@ -20,6 +20,6 @@ class InMemoryCommandHandlerMapTest extends \PHPUnit_Framework_TestCase
     {
         $inMemoryCommandHandlerMap = new InMemoryCommandHandlerMap(['Command' => 'CommandHandler']);
 
-        $this->assertSame($inMemoryCommandHandlerMap->getCommand('Command'), 'CommandHandler');
+        $this->assertSame('CommandHandler', $inMemoryCommandHandlerMap->getCommand('Command'));
     }
 }


### PR DESCRIPTION
According to PHPUnit documentation, the first parameter of an assertion is the expected value:
https://phpunit.de/manual/current/en/phpunit-book.html#appendixes.assertions.assertSame